### PR TITLE
PelEntryNumber::setValue() declaration fix

### DIFF
--- a/src/PelEntryNumber.php
+++ b/src/PelEntryNumber.php
@@ -134,7 +134,7 @@ abstract class PelEntryNumber extends PelEntry {
      *
      * @see getValue
      */
-    function setValue(/* $value... */) {
+    function setValue($value) {
         $value = func_get_args();
         $this->setValueArray($value);
     }


### PR DESCRIPTION
PelEntryNumber::setValue() must have the same declaration with its parent's, PelEntry.
