### PR TITLE
Changed access of the $sections property

### DIFF
--- a/src/PelJpeg.php
+++ b/src/PelJpeg.php
@@ -78,7 +78,7 @@ class PelJpeg
      *
      * @var array
      */
-    private $sections = array();
+    protected $sections = array();
 
     /**
      * The JPEG image data.


### PR DESCRIPTION
Changed access of the $sections property to allow section manipulations in subclasses.
This allows to control other sections, e.g. APP13 IPTC section in the subclass.
Another option would be bring section manipulations into the PelJpeg class, but since Pel's responsibility is EXIF only, PelJpeg's functionality is sufficient.