### PR TITLE
TravisCI tests up to PHP 7.4 and fix PHP 7.4 syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,20 @@ language: php
 sudo: false
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
   - nightly
 
 matrix:
   include:
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
     - php: hhvm
       dist: trusty
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4
+  - 7.4snapshot
   - nightly
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,12 @@ matrix:
       dist: trusty
     - php: 5.5
       dist: trusty
-    - php: hhvm
-      dist: trusty
   fast_finish: true
   allow_failures:
     - php: hhvm
     - php: nightly
 
 install:
-  - travis_retry composer self-update
   - travis_retry composer install --no-interaction --no-progress --no-suggest
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev" : {
         "ext-gd": "*",
-        "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5",
+        "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7",
         "squizlabs/php_codesniffer": "^3.0.0",
         "satooshi/php-coveralls": "1.0.*"
     },

--- a/src/PelConvert.php
+++ b/src/PelConvert.php
@@ -148,11 +148,11 @@ class PelConvert
          */
         $hex = str_pad(base_convert($value, 10, 16), 8, '0', STR_PAD_LEFT);
         if ($endian == self::LITTLE_ENDIAN) {
-            return (chr(hexdec($hex{6} . $hex{7})) . chr(hexdec($hex{4} . $hex{5})) . chr(hexdec($hex{2} . $hex{3})) .
-                 chr(hexdec($hex{0} . $hex{1})));
+            return (chr(hexdec($hex[6] . $hex[7])) . chr(hexdec($hex[4] . $hex[5])) . chr(hexdec($hex[2] . $hex[3])) .
+                 chr(hexdec($hex[0] . $hex[1])));
         } else {
-            return (chr(hexdec($hex{0} . $hex{1})) . chr(hexdec($hex{2} . $hex{3})) . chr(hexdec($hex{4} . $hex{5})) .
-                 chr(hexdec($hex{6} . $hex{7})));
+            return (chr(hexdec($hex[0] . $hex[1])) . chr(hexdec($hex[2] . $hex[3])) . chr(hexdec($hex[4] . $hex[5])) .
+                 chr(hexdec($hex[6] . $hex[7])));
         }
     }
 

--- a/src/PelConvert.php
+++ b/src/PelConvert.php
@@ -201,7 +201,7 @@ class PelConvert
      */
     public static function bytesToByte($bytes, $offset)
     {
-        return ord($bytes{$offset});
+        return ord($bytes[$offset]);
     }
 
     /**
@@ -248,9 +248,9 @@ class PelConvert
     public static function bytesToShort($bytes, $offset, $endian)
     {
         if ($endian == self::LITTLE_ENDIAN) {
-            return (ord($bytes{$offset + 1}) * 256 + ord($bytes{$offset}));
+            return (ord($bytes[$offset + 1]) * 256 + ord($bytes[$offset]));
         } else {
-            return (ord($bytes{$offset}) * 256 + ord($bytes{$offset + 1}));
+            return (ord($bytes[$offset]) * 256 + ord($bytes[$offset + 1]));
         }
     }
 
@@ -299,11 +299,11 @@ class PelConvert
     public static function bytesToLong($bytes, $offset, $endian)
     {
         if ($endian == self::LITTLE_ENDIAN) {
-            return (ord($bytes{$offset + 3}) * 16777216 + ord($bytes{$offset + 2}) * 65536 +
-                 ord($bytes{$offset + 1}) * 256 + ord($bytes{$offset}));
+            return (ord($bytes[$offset + 3]) * 16777216 + ord($bytes[$offset + 2]) * 65536 +
+                 ord($bytes[$offset + 1]) * 256 + ord($bytes[$offset]));
         } else {
-            return (ord($bytes{$offset}) * 16777216 + ord($bytes{$offset + 1}) * 65536 + ord($bytes{$offset + 2}) * 256 +
-                 ord($bytes{$offset + 3}));
+            return (ord($bytes[$offset]) * 16777216 + ord($bytes[$offset + 1]) * 65536 + ord($bytes[$offset + 2]) * 256 +
+                 ord($bytes[$offset + 3]));
         }
     }
 
@@ -407,7 +407,7 @@ class PelConvert
         $line = 24;
 
         for ($i = 0; $i < $s; $i ++) {
-            printf('%02X ', ord($bytes{$i}));
+            printf('%02X ', ord($bytes[$i]));
 
             if (($i + 1) % $line == 0) {
                 print("\n");

--- a/src/PelDataWindow.php
+++ b/src/PelDataWindow.php
@@ -541,7 +541,7 @@ class PelDataWindow
 
         /* Check each character, return as soon as the answer is known. */
         for ($i = 0; $i < $s; $i ++) {
-            if ($this->data{$offset + $i} != $str{$i}) {
+            if ($this->data[$offset + $i] != $str[$i]) {
                 return false;
             }
         }

--- a/src/PelEntryUndefined.php
+++ b/src/PelEntryUndefined.php
@@ -110,27 +110,27 @@ class PelEntryUndefined extends PelEntry
         switch ($this->tag) {
             case PelTag::FILE_SOURCE:
                 // CC (e->components, 1, v);
-                switch (ord($this->bytes{0})) {
+                switch (ord($this->bytes[0])) {
                     case 0x03:
                         return 'DSC';
                     default:
-                        return sprintf('0x%02X', ord($this->bytes{0}));
+                        return sprintf('0x%02X', ord($this->bytes[0]));
                 }
                 break;
             case PelTag::SCENE_TYPE:
                 // CC (e->components, 1, v);
-                switch (ord($this->bytes{0})) {
+                switch (ord($this->bytes[0])) {
                     case 0x01:
                         return 'Directly photographed';
                     default:
-                        return sprintf('0x%02X', ord($this->bytes{0}));
+                        return sprintf('0x%02X', ord($this->bytes[0]));
                 }
                 break;
             case PelTag::COMPONENTS_CONFIGURATION:
                 // CC (e->components, 4, v);
                 $v = '';
                 for ($i = 0; $i < 4; $i ++) {
-                    switch (ord($this->bytes{$i})) {
+                    switch (ord($this->bytes[$i])) {
                         case 0:
                             $v .= '-';
                             break;


### PR DESCRIPTION
The library needs to update syntax for string offset access to be PHP 7.4 compatible.

Here upping the tests to PHP 7.4 and making the bare minimum changes required.

Once PHP 7.4 compatibility is fixed we will need a new release.