### PR TITLE
Handle non-numeric values from PelFormat::getSize

### DIFF
--- a/src/PelIfd.php
+++ b/src/PelIfd.php
@@ -444,8 +444,9 @@ class PelIfd implements \IteratorAggregate, \ArrayAccess
          * not in the entry but somewhere else, with the offset stored
          * in the entry.
          */
-        $s = PelFormat::getSize($format) * $components;
-        if ($s > 0) {
+        $elemSize = PelFormat::getSize($format);
+        if (is_numeric($elemSize) && $elemSize > 0) {
+            $s = $elemSize * $components;
             $doff = $offset + 12 * $i + 8;
             if ($s > 4) {
                 $doff = $d->getLong($doff);


### PR DESCRIPTION
PelFormat::getSize can also return non-numeric values (string, in case of an error). We should handle those cases correctly.

In my case, this is the warning I see (only the relevant backtrace is shown here).
```
Warning: A non-numeric value encountered in lsolesen\pel\PelIfd->loadSingleValue() (line 447 of /var/www/.../vendor/lsolesen/pel/src/PelIfd.php) #0 /var/www/.../web/core/includes/bootstrap.inc(600): _drupal_error_handler_real(2, 'A non-numeric v...', '/var/www/...', 447, Array)
#1 /var/www/.../vendor/lsolesen/pel/src/PelIfd.php(447): _drupal_error_handler(2, 'A non-numeric v...', '/var/www/...', 447, Array)
#2 /var/www/.../vendor/lsolesen/pel/src/PelCanonMakerNotes.php(215): lsolesen\pel\PelIfd->loadSingleValue(Object(lsolesen\pel\PelDataWindow), 4908, 71, 19200)
#3 /var/www/.../vendor/lsolesen/pel/src/PelIfd.php(406): lsolesen\pel\PelCanonMakerNotes->load()
#4 /var/www/.../vendor/lsolesen/pel/src/PelTiff.php(159): lsolesen\pel\PelIfd->load(Object(lsolesen\pel\PelDataWindow), 10)
#5 /var/www/.../vendor/lsolesen/pel/src/PelExif.php(108): lsolesen\pel\PelTiff->load(Object(lsolesen\pel\PelDataWindow))
#6 /var/www/.../vendor/lsolesen/pel/src/PelJpeg.php(216): lsolesen\pel\PelExif->load(Object(lsolesen\pel\PelDataWindow))
#7 /var/www/.../vendor/lsolesen/pel/src/PelJpeg.php(286): lsolesen\pel\PelJpeg->load(Object(lsolesen\pel\PelDataWindow))
#8 /var/www/.../vendor/lsolesen/pel/src/PelJpeg.php(123): lsolesen\pel\PelJpeg->loadFile('public://photos...')
```