### PR TITLE
Cast output from getBytes() to float

### DIFF
--- a/src/PelIfd.php
+++ b/src/PelIfd.php
@@ -608,7 +608,7 @@ class PelIfd implements \IteratorAggregate, \ArrayAccess
                         if ($format != PelFormat::UNDEFINED) {
                             throw new PelUnexpectedFormatException($this->type, $tag, $format, PelFormat::UNDEFINED);
                         }
-                        return new PelEntryVersion($tag, $data->getBytes() / 100);
+                        return new PelEntryVersion($tag, (float) $data->getBytes() / 100);
 
                     case PelTag::USER_COMMENT:
                         if ($format != PelFormat::UNDEFINED) {


### PR DESCRIPTION
Since $data->getBytes() returns a string, it is implicitly converted to a number before dividing by 100. But if the string returned is not numeric, then there is a warning raised. This change suppresses the warning without changing existing behaviour.

This is the warning I see (only the relevant bit):
```
Warning: A non-numeric value encountered in lsolesen\pel\PelIfd->newEntryFromData() (line 611 of /var/www/.../vendor/lsolesen/pel/src/PelIfd.php) #0 /var/www/.../web/core/includes/bootstrap.inc(600): _drupal_error_handler_real(2, 'A non-numeric v...', '/var/www/...', 611, Array)
#1 /var/www/.../vendor/lsolesen/pel/src/PelIfd.php(611): _drupal_error_handler(2, 'A non-numeric v...', '/var/www/...', 611, Array)
#2 /var/www/.../vendor/lsolesen/pel/src/PelIfd.php(459): lsolesen\pel\PelIfd->newEntryFromData(2, 7, 4, Object(lsolesen\pel\PelDataWindow))
#3 /var/www/.../vendor/lsolesen/pel/src/PelIfd.php(368): lsolesen\pel\PelIfd->loadSingleValue(Object(lsolesen\pel\PelDataWindow), 35344, 1, 2)
#4 /var/www/.../vendor/lsolesen/pel/src/PelIfd.php(350): lsolesen\pel\PelIfd->load(Object(lsolesen\pel\PelDataWindow), 35344)
#5 /var/www/.../vendor/lsolesen/pel/src/PelIfd.php(350): lsolesen\pel\PelIfd->load(Object(lsolesen\pel\PelDataWindow), 240)
#6 /var/www/.../vendor/lsolesen/pel/src/PelTiff.php(159): lsolesen\pel\PelIfd->load(Object(lsolesen\pel\PelDataWindow), 10)
#7 /var/www/.../vendor/lsolesen/pel/src/PelExif.php(108): lsolesen\pel\PelTiff->load(Object(lsolesen\pel\PelDataWindow))
#8 /var/www/.../vendor/lsolesen/pel/src/PelJpeg.php(216): lsolesen\pel\PelExif->load(Object(lsolesen\pel\PelDataWindow))
#9 /var/www/.../vendor/lsolesen/pel/src/PelJpeg.php(286): lsolesen\pel\PelJpeg->load(Object(lsolesen\pel\PelDataWindow))
#10 /var/www/.../vendor/lsolesen/pel/src/PelJpeg.php(123): lsolesen\pel\PelJpeg->loadFile('public://photos...')
```