### PR TITLE
Fix 'A non-numeric value encountered'

### DIFF
--- a/src/PelIfd.php
+++ b/src/PelIfd.php
@@ -444,7 +444,7 @@ class PelIfd implements \IteratorAggregate, \ArrayAccess
          * not in the entry but somewhere else, with the offset stored
          * in the entry.
          */
-        $s = PelFormat::getSize($format) * $components;
+        $s = (int) PelFormat::getSize($format) * $components;
         if ($s > 0) {
             $doff = $offset + 12 * $i + 8;
             if ($s > 4) {
@@ -505,7 +505,7 @@ class PelIfd implements \IteratorAggregate, \ArrayAccess
      */
     public function loadSingleMakerNotesValue($type, $data, $offset, $size, $i, $format)
     {
-        $elemSize = PelFormat::getSize($format);
+        $elemSize = (int) PelFormat::getSize($format);
         if ($size > 0) {
             $subdata = $data->getClone($offset + $i * $elemSize, $elemSize);
         } else {


### PR DESCRIPTION
```
-> [#00] /app/vendor/lsolesen/pel/src/PelIfd.php:447
-> [#01] /app/vendor/lsolesen/pel/src/PelCanonMakerNotes.php:215 --- lsolesen\pel\PelIfd::loadSingleValue(<lsolesen\pel\PelDataWindow>, '766', '309', '62383')
-> [#02] /app/vendor/lsolesen/pel/src/PelIfd.php:406 --- lsolesen\pel\PelCanonMakerNotes::load()
-> [#03] /app/vendor/lsolesen/pel/src/PelTiff.php:159 --- lsolesen\pel\PelIfd::load(<lsolesen\pel\PelDataWindow>, '10')
-> [#04] /app/vendor/lsolesen/pel/src/PelExif.php:108 --- lsolesen\pel\PelTiff::load(<lsolesen\pel\PelDataWindow>)
-> [#05] /app/vendor/lsolesen/pel/src/PelJpeg.php:216 --- lsolesen\pel\PelExif::load(<lsolesen\pel\PelDataWindow>)
-> [#06] /app/vendor/lsolesen/pel/src/PelJpeg.php:126 --- lsolesen\pel\PelJpeg::load(<lsolesen\pel\PelDataWindow>)
```