### PR TITLE
Fixes regarding phpdoc and variable-usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build-base*
 /.phpcs-cache
 /.phpunit.result.cache
 /composer.lock
+/.settings/

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
   environment:
-    php: '7.2'
+    php: '7.4'
 
   tests:
     override:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
   environment:
-    php: '7.3'
+    php: '7.2'
 
   tests:
     override:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
   environment:
-    php: '7.4'
+    php: '7.3'
 
   tests:
     override:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev" : {
         "ext-gd": "*",
-        "squizlabs/php_codesniffer": ">3.5",
+        "squizlabs/php_codesniffer": ">3.5.8",
         "php-coveralls/php-coveralls": ">2.4",
         "symfony/phpunit-bridge": "^4 || ^5"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev" : {
         "ext-gd": "*",
-        "squizlabs/php_codesniffer": ">3.5.8",
+        "squizlabs/php_codesniffer": ">3.5",
         "php-coveralls/php-coveralls": ">2.4",
         "symfony/phpunit-bridge": "^4 || ^5"
     },

--- a/examples/dirsort.php
+++ b/examples/dirsort.php
@@ -25,6 +25,13 @@
  */
 
 /* a printf() variant that appends a newline to the output. */
+
+use lsolesen\pel\Pel;
+use lsolesen\pel\PelDataWindow;
+use lsolesen\pel\PelJpeg;
+use lsolesen\pel\PelTag;
+use lsolesen\pel\PelTiff;
+
 function println($args)
 {
     $args = func_get_args();
@@ -34,14 +41,8 @@ function println($args)
 
 /* Make PEL speak the users language, if it is available. */
 setlocale(LC_ALL, '');
-require_once '../autoload.php';
-
-use lsolesen\pel\PelDataWindow;
-use lsolesen\pel\PelJpeg;
-use lsolesen\pel\PelTiff;
 
 $prog = array_shift($argv);
-$error = false;
 
 if (isset($argv[0]) && $argv[0] == '-d') {
     Pel::setDebug(true);

--- a/examples/dump-image.php
+++ b/examples/dump-image.php
@@ -27,9 +27,8 @@
 /* Make PEL speak the users language, if it is available. */
 setlocale(LC_ALL, '');
 
-require_once dirname(__FILE__) . '/../vendor/autoload.php';
-
 use lsolesen\pel\Pel;
+use lsolesen\pel\PelConvert;
 use lsolesen\pel\PelDataWindow;
 use lsolesen\pel\PelJpeg;
 use lsolesen\pel\PelTiff;

--- a/examples/edit-description.php
+++ b/examples/edit-description.php
@@ -25,6 +25,16 @@
  */
 
 /* a printf() variant that appends a newline to the output. */
+use lsolesen\pel\Pel;
+use lsolesen\pel\PelConvert;
+use lsolesen\pel\PelDataWindow;
+use lsolesen\pel\PelEntryAscii;
+use lsolesen\pel\PelExif;
+use lsolesen\pel\PelIfd;
+use lsolesen\pel\PelJpeg;
+use lsolesen\pel\PelTag;
+use lsolesen\pel\PelTiff;
+
 function println($args)
 {
     $args = func_get_args();
@@ -34,18 +44,6 @@ function println($args)
 
 /* Make PEL speak the users language, if it is available. */
 setlocale(LC_ALL, '');
-
-/*
- * Load the required files. One would normally just require the
- * PelJpeg.php file for dealing with JPEG images, but because this
- * example can handle both JPEG and TIFF it loads the PelDataWindow
- * class too.
- */
-require_once '../autoload.php';
-
-use lsolesen\pel\PelDataWindow;
-use lsolesen\pel\PelJpeg;
-use lsolesen\pel\PelTiff;
 
 /*
  * Store the name of the script in $prog and remove this first part of

--- a/examples/gps.php
+++ b/examples/gps.php
@@ -34,9 +34,14 @@
  * used in Exif data.
  * - addGpsInfo() adds several Exif tags to your JPEG file.
  */
-require_once '../autoload.php';
-
+use lsolesen\pel\PelEntryAscii;
+use lsolesen\pel\PelEntryByte;
+use lsolesen\pel\PelEntryRational;
+use lsolesen\pel\PelEntryUserComment;
+use lsolesen\pel\PelExif;
+use lsolesen\pel\PelIfd;
 use lsolesen\pel\PelJpeg;
+use lsolesen\pel\PelTag;
 use lsolesen\pel\PelTiff;
 
 /**
@@ -94,25 +99,25 @@ function convertDecimalToDMS($degree)
  * Any old Exif data
  * is discarded.
  *
- * @param
- *            string the input filename.
- * @param
- *            string the output filename. An updated copy of the input
+ * @param string $input
+ *            the input filename.
+ * @param string $output
+ *            the output filename. An updated copy of the input
  *            image is saved here.
- * @param
- *            string image description.
- * @param
- *            string user comment.
- * @param
- *            string camera model.
- * @param
- *            float longitude expressed as a fractional number of degrees,
+ * @param string $description
+ *            image description.
+ * @param string $comment
+ *            user comment.
+ * @param string $model
+ *            camera model.
+ * @param float $longitude
+ *            expressed as a fractional number of degrees,
  *            e.g. 12.345�. Negative values denotes degrees west of Greenwich.
- * @param
- *            float latitude expressed as for longitude. Negative values
+ * @param float $latitude
+ *            expressed as for longitude. Negative values
  *            denote degrees south of equator.
- * @param
- *            float the altitude, negative values express an altitude
+ * @param float $date_time
+ *            the altitude, negative values express an altitude
  *            below sea level.
  * @param
  *            string the date and time.

--- a/examples/rename.php
+++ b/examples/rename.php
@@ -34,6 +34,12 @@
  */
 
 /* a printf() variant that appends a newline to the output. */
+use lsolesen\pel\Pel;
+use lsolesen\pel\PelDataWindow;
+use lsolesen\pel\PelJpeg;
+use lsolesen\pel\PelTag;
+use lsolesen\pel\PelTiff;
+
 function println($args)
 {
     $args = func_get_args();
@@ -44,12 +50,6 @@ function println($args)
 /* Make PEL speak the users language, if it is available. */
 setlocale(LC_ALL, '');
 
-/* Load the required class definitions. */
-require_once '../autoload.php';
-
-use lsolesen\pel\PelDataWindow;
-use lsolesen\pel\PelJpeg;
-use lsolesen\pel\PelTiff;
 
 $prog = array_shift($argv);
 $error = false;

--- a/examples/resize.php
+++ b/examples/resize.php
@@ -25,6 +25,9 @@
  */
 
 /* a printf() variant that appends a newline to the output. */
+use lsolesen\pel\Pel;
+use lsolesen\pel\PelJpeg;
+
 function println($args)
 {
     $args = func_get_args();
@@ -34,11 +37,6 @@ function println($args)
 
 /* Make PEL speak the users language, if it is available. */
 setlocale(LC_ALL, '');
-
-/* Load the required PEL files for handling JPEG images. */
-require_once '../autoload.php';
-
-use lsolesen\pel\PelJpeg;
 
 /*
  * Store the name of the script in $prog and remove this first part of

--- a/src/Pel.php
+++ b/src/Pel.php
@@ -33,7 +33,6 @@
  * true or false to {@link Pel::$debug}.
  *
  * @author Martin Geisler <mgeisler@users.sourceforge.net>
- * @package PEL
  */
 namespace lsolesen\pel;
 

--- a/src/PelCanonMakerNotes.php
+++ b/src/PelCanonMakerNotes.php
@@ -188,7 +188,6 @@ class PelCanonMakerNotes extends PelMakerNotes
 
         for ($i = 0; $i < $this->components; $i ++) {
             $tag = $this->data->getShort($this->offset + 12 * $i);
-            $type = $this->data->getShort($this->offset + 12 * $i + 2);
             $components = $this->data->getLong($this->offset + 12 * $i + 4);
             $data = $this->data->getLong($this->offset + 12 * $i + 8);
             // check if tag is defined
@@ -206,6 +205,7 @@ class PelCanonMakerNotes extends PelMakerNotes
                     $this->parsePanorama($mkNotesIfd, $this->data, $data, $components);
                     break;
                 case PelTag::CANON_PICTURE_INFO:
+                    // TODO: Does not work at the moment
                     // $this->parsePictureInfo($mkNotesIfd, $this->data, $data, $components);
                     break;
                 case PelTag::CANON_FILE_INFO:
@@ -287,6 +287,9 @@ class PelCanonMakerNotes extends PelMakerNotes
         $parent->addSubIfd($panoramaIfd);
     }
 
+    /**
+     * This method does not work properly
+     */
     private function parsePictureInfo($parent, $data, $offset, $components)
     {
         $type = PelIfd::CANON_PICTURE_INFO;

--- a/src/PelConvert.php
+++ b/src/PelConvert.php
@@ -22,6 +22,7 @@
  * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
  * Boston, MA 02110-1301 USA
  */
+namespace lsolesen\pel;
 
 /**
  * Routines for converting back and forth between bytes and integers.
@@ -50,8 +51,6 @@
  * @author Martin Geisler <mgeisler@users.sourceforge.net>
  * @package PEL
  */
-namespace lsolesen\pel;
-
 class PelConvert
 {
 
@@ -143,9 +142,9 @@ class PelConvert
          */
         $hex = str_pad(base_convert($value, 10, 16), 8, '0', STR_PAD_LEFT);
         if ($endian == self::LITTLE_ENDIAN) {
-            return (chr(hexdec($hex[6] . $hex[7])) . chr(hexdec($hex[4] . $hex[5])) . chr(hexdec($hex[2] . $hex[3])) . chr(hexdec($hex[0] . $hex[1])));
+            return chr((int) hexdec($hex[6] . $hex[7])) . chr((int) hexdec($hex[4] . $hex[5])) . chr((int) hexdec($hex[2] . $hex[3])) . chr((int) hexdec($hex[0] . $hex[1]));
         } else {
-            return (chr(hexdec($hex[0] . $hex[1])) . chr(hexdec($hex[2] . $hex[3])) . chr(hexdec($hex[4] . $hex[5])) . chr(hexdec($hex[6] . $hex[7])));
+            return chr((int) hexdec($hex[0] . $hex[1])) . chr((int) hexdec($hex[2] . $hex[3])) . chr((int) hexdec($hex[4] . $hex[5])) . chr((int) hexdec($hex[6] . $hex[7]));
         }
     }
 

--- a/src/PelDataWindow.php
+++ b/src/PelDataWindow.php
@@ -49,7 +49,7 @@ class PelDataWindow
      * PelConvert::LITTLE_ENDIAN} and {@link PelConvert::BIG_ENDIAN}.
      *
      * @var boolean
-     * @see PelDataWindow::setByteOrder, PelDataWindow::getByteOrder
+     * @see PelDataWindow::setByteOrder, getByteOrder
      */
     private $order;
 

--- a/src/PelDataWindowOffsetException.php
+++ b/src/PelDataWindowOffsetException.php
@@ -22,6 +22,7 @@
  * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
  * Boston, MA 02110-1301 USA
  */
+namespace lsolesen\pel;
 
 /**
  * An exception thrown when an invalid offset is encountered.
@@ -29,8 +30,6 @@
  * @package PEL
  * @subpackage Exception
  */
-namespace lsolesen\pel;
-
 class PelDataWindowOffsetException extends PelException
 {
 }

--- a/src/PelDataWindowWindowException.php
+++ b/src/PelDataWindowWindowException.php
@@ -22,6 +22,7 @@
  * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
  * Boston, MA 02110-1301 USA
  */
+namespace lsolesen\pel;
 
 /**
  * A container for bytes with a limited window of accessible bytes.
@@ -37,8 +38,6 @@
  * @package PEL
  * @subpackage Exception
  */
-namespace lsolesen\pel;
-
 class PelDataWindowWindowException extends PelException
 {
 }

--- a/src/PelEntry.php
+++ b/src/PelEntry.php
@@ -138,8 +138,8 @@ abstract class PelEntry
     /**
      * Update the IFD type.
      *
-     * @param
-     *            int must be one of the constants defined in {@link
+     * @param int $type
+     *            must be one of the constants defined in {@link
      *            PelIfd}: {@link PelIfd::IFD0} for the main image IFD, {@link
      *            PelIfd::IFD1} for the thumbnail image IFD, {@link PelIfd::EXIF}
      *            for the Exif sub-IFD, {@link PelIfd::GPS} for the GPS sub-IFD, or
@@ -174,8 +174,8 @@ abstract class PelEntry
     /**
      * Turn this entry into bytes.
      *
-     * @param
-     *            PelByteOrder the desired byte order, which must be either
+     * @param boolean $o
+     *            the desired byte order, which must be either
      *            {@link Convert::LITTLE_ENDIAN} or {@link Convert::BIG_ENDIAN}.
      * @return string bytes representing this entry.
      */
@@ -191,8 +191,8 @@ abstract class PelEntry
      * e.g., rationals will be returned as 'x/y', ASCII strings will be
      * returned as themselves etc.
      *
-     * @param
-     *            boolean some values can be returned in a long or more
+     * @param boolean $brief
+     *            some values can be returned in a long or more
      *            brief form, and this parameter controls that.
      * @return string the value as text.
      */
@@ -214,8 +214,8 @@ abstract class PelEntry
      *
      * The value should be in the same format as for the constructor.
      *
-     * @param
-     *            mixed the new value.
+     * @param mixed $value
+     *            the new value.
      * @abstract
      *
      */

--- a/src/PelEntryAscii.php
+++ b/src/PelEntryAscii.php
@@ -88,20 +88,13 @@ class PelEntryAscii extends PelEntry
     {
         $this->tag = $tag;
         $this->format = PelFormat::ASCII;
-        self::setValue($str);
+        $this->setValue($str);
     }
 
     /**
-     * Give the entry a new ASCII value.
      *
-     * This will overwrite the previous value. The value can be
-     * retrieved later with the {@link getValue} method.
-     *
-     * @param
-     *            string the new value of the entry. This should be given
-     *            without any trailing NULL character. The string must be plain
-     *            7-bit ASCII, the string should contain no high bytes.
-     * @todo Implement check for high bytes?
+     * {@inheritdoc}
+     * @see \lsolesen\pel\PelEntry::setValue()
      */
     public function setValue($str)
     {
@@ -111,11 +104,9 @@ class PelEntryAscii extends PelEntry
     }
 
     /**
-     * Return the ASCII string of the entry.
      *
-     * @return string the string held, without any final NULL character.
-     *         The string will be the same as the one given to {@link setValue}
-     *         or to the {@link __construct constructor}.
+     * {@inheritdoc}
+     * @see \lsolesen\pel\PelEntry::getValue()
      */
     public function getValue()
     {
@@ -123,15 +114,9 @@ class PelEntryAscii extends PelEntry
     }
 
     /**
-     * Return the ASCII string of the entry.
      *
-     * This methods returns the same as {@link getValue}.
-     *
-     * @param
-     *            boolean not used with ASCII entries.
-     * @return string the string held, without any final NULL character.
-     *         The string will be the same as the one given to {@link setValue}
-     *         or to the {@link __construct constructor}.
+     * {@inheritdoc}
+     * @see \lsolesen\pel\PelEntry::getText()
      */
     public function getText($brief = false)
     {

--- a/src/PelEntryByte.php
+++ b/src/PelEntryByte.php
@@ -81,14 +81,9 @@ class PelEntryByte extends PelEntryNumber
     }
 
     /**
-     * Convert a number into bytes.
      *
-     * @param int $number
-     *            the number that should be converted.
-     * @param boolean $order
-     *            one of {@link PelConvert::LITTLE_ENDIAN} and
-     *            {@link PelConvert::BIG_ENDIAN}, specifying the target byte order.
-     * @return string bytes representing the number given.
+     * {@inheritdoc}
+     * @see \lsolesen\pel\PelEntryNumber::numberToBytes()
      */
     public function numberToBytes($number, $order)
     {

--- a/src/PelEntryCopyright.php
+++ b/src/PelEntryCopyright.php
@@ -24,24 +24,6 @@
  */
 
 /**
- * Classes used to hold ASCII strings.
- *
- * The classes defined here are to be used for Exif entries holding
- * ASCII strings, such as {@link PelTag::MAKE}, {@link
- * PelTag::SOFTWARE}, and {@link PelTag::DATE_TIME}. For
- * entries holding normal textual ASCII strings the class {@link
- * PelEntryAscii} should be used, but for entries holding
- * timestamps the class {@link PelEntryTime} would be more
- * convenient instead. Copyright information is handled by the {@link
- * PelEntryCopyright} class.
- *
- * @author Martin Geisler <mgeisler@users.sourceforge.net>
- * @license http://www.gnu.org/licenses/gpl.html GNU General Public
- *          License (GPL)
- * @package PEL
- */
-
-/**
  * Class for holding copyright information.
  *
  * The Exif standard specifies a certain format for copyright
@@ -89,11 +71,11 @@ class PelEntryCopyright extends PelEntryAscii
     /**
      * Make a new entry for holding copyright information.
      *
-     * @param
-     *            string the photographer copyright. Use the empty string
+     * @param string $photographer
+     *            the photographer copyright. Use the empty string
      *            if there is no photographer copyright.
-     * @param
-     *            string the editor copyright. Use the empty string if
+     * @param string $editor
+     *            the editor copyright. Use the empty string if
      *            there is no editor copyright.
      */
     public function __construct($photographer = '', $editor = '')
@@ -155,8 +137,8 @@ class PelEntryCopyright extends PelEntryAscii
      * with a '-' in between if both copyright fields are present,
      * otherwise only one of them will be returned.
      *
-     * @param
-     *            boolean if false, then the strings '(Photographer)' and
+     * @param boolean $brief
+     *            if false, then the strings '(Photographer)' and
      *            '(Editor)' will be appended to the photographer and editor
      *            copyright fields (if present), otherwise the fields will be
      *            returned as is.

--- a/src/PelEntryLong.php
+++ b/src/PelEntryLong.php
@@ -22,6 +22,7 @@
  * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
  * Boston, MA 02110-1301 USA
  */
+namespace lsolesen\pel;
 
 /**
  * Classes used to hold longs, both signed and unsigned.
@@ -51,8 +52,6 @@
  * @author Martin Geisler <mgeisler@users.sourceforge.net>
  * @package PEL
  */
-namespace lsolesen\pel;
-
 class PelEntryLong extends PelEntryNumber
 {
 
@@ -74,8 +73,8 @@ class PelEntryLong extends PelEntryNumber
      * of an array with one integer element, which would then have to be
      * extracted.
      *
-     * @param
-     *            int the tag which this entry represents. This
+     * @param int $tag
+     *            the tag which this entry represents. This
      *            should be one of the constants defined in {@link PelTag},
      *            e.g., {@link PelTag::IMAGE_WIDTH}, or any other tag which can
      *            have format {@link PelFormat::LONG}.
@@ -102,10 +101,10 @@ class PelEntryLong extends PelEntryNumber
     /**
      * Convert a number into bytes.
      *
-     * @param
-     *            int the number that should be converted.
-     * @param
-     *            PelByteOrder one of {@link PelConvert::LITTLE_ENDIAN} and
+     * @param int $number
+     *            the number that should be converted.
+     * @param boolean $order
+     *            one of {@link PelConvert::LITTLE_ENDIAN} and
      *            {@link PelConvert::BIG_ENDIAN}, specifying the target byte order.
      * @return string bytes representing the number given.
      */

--- a/src/PelEntryNumber.php
+++ b/src/PelEntryNumber.php
@@ -99,7 +99,7 @@ abstract class PelEntryNumber extends PelEntry
      *            more numbers, that is, either integers or arrays. The input will
      *            be checked to ensure that the numbers are within the valid range.
      *            If not, then a {@link PelOverflowException} will be thrown.
-     * @see getValue
+     * @see PelEntryNumber::getValue
      */
     public function setValue($value)
     {
@@ -115,19 +115,19 @@ abstract class PelEntryNumber extends PelEntry
      * value, and a {@link PelOverflowException} will be thrown if the
      * value is found to be outside the legal range.
      *
-     * @param
-     *            array the new values. The array must contain the new
+     * @param array $values
+     *            the new values. The array must contain the new
      *            numbers.
-     * @see getValue
+     * @see PelEntryNumber::getValue
      */
-    public function setValueArray($value)
+    public function setValueArray($values)
     {
-        foreach ($value as $v) {
+        foreach ($values as $v) {
             $this->validateNumber($v);
         }
 
-        $this->components = count($value);
-        $this->value = $value;
+        $this->components = count($values);
+        $this->value = $values;
     }
 
     /**
@@ -152,8 +152,8 @@ abstract class PelEntryNumber extends PelEntry
      * given my {@link getMin()} and {@link getMax()}, inclusive. If
      * not, then a {@link PelOverflowException} is thrown.
      *
-     * @param
-     *            int|array the number in question.
+     * @param int|array $n
+     *            the number in question.
      * @return void nothing, but will throw a {@link
      *         PelOverflowException} if the number is found to be outside the
      *         legal range and {@link Pel::$strict} is true.
@@ -162,7 +162,7 @@ abstract class PelEntryNumber extends PelEntry
     {
         if ($this->dimension == 1 || is_scalar($n)) {
             if ($n < $this->min || $n > $this->max) {
-                Pel::maybeThrow(new PelOverflowException($n, $this->min, $this->max));
+                Pel::maybeThrow(new PelOverflowException((int) $n, $this->min, $this->max));
             }
         } else {
             for ($i = 0; $i < $this->dimension; $i ++) {
@@ -182,8 +182,8 @@ abstract class PelEntryNumber extends PelEntry
      * This appends a number to the numbers already held by this entry,
      * thereby increasing the number of components by one.
      *
-     * @param
-     *            int|array the number to be added.
+     * @param int|array $n
+     *            the number to be added.
      */
     public function addNumber($n)
     {
@@ -200,10 +200,10 @@ abstract class PelEntryNumber extends PelEntry
      *
      * The method will be called once for each number held by the entry.
      *
-     * @param
-     *            int the number that should be converted.
-     * @param
-     *            PelByteOrder one of {@link PelConvert::LITTLE_ENDIAN} and
+     * @param int $number
+     *            the number that should be converted.
+     * @param boolean $order
+     *            one of {@link PelConvert::LITTLE_ENDIAN} and
      *            {@link PelConvert::BIG_ENDIAN}, specifying the target byte order.
      * @return string bytes representing the number given.
      */
@@ -212,8 +212,8 @@ abstract class PelEntryNumber extends PelEntry
     /**
      * Turn this entry into bytes.
      *
-     * @param
-     *            PelByteOrder the desired byte order, which must be either
+     * @param boolean $o
+     *            the desired byte order, which must be either
      *            {@link PelConvert::LITTLE_ENDIAN} or {@link
      *            PelConvert::BIG_ENDIAN}.
      * @return string bytes representing this entry.
@@ -241,10 +241,10 @@ abstract class PelEntryNumber extends PelEntry
      * sophisticated behavior than the default, which is to just return
      * the number as is.
      *
-     * @param
-     *            int the number which will be formatted.
-     * @param
-     *            boolean it could be that there is both a verbose and a
+     * @param int $number
+     *            the number which will be formatted.
+     * @param boolean $brief
+     *            it could be that there is both a verbose and a
      *            brief formatting available, and this argument controls that.
      * @return string the number formatted as a string suitable for
      *         display.
@@ -257,8 +257,8 @@ abstract class PelEntryNumber extends PelEntry
     /**
      * Get the numeric value of this entry as text.
      *
-     * @param
-     *            boolean use brief output? The numbers will be separated
+     * @param boolean $brief
+     *            use brief output? The numbers will be separated
      *            by a single space if brief output is requested, otherwise a space
      *            and a comma will be used.
      * @return string the numbers(s) held by this entry.

--- a/src/PelEntryRational.php
+++ b/src/PelEntryRational.php
@@ -65,8 +65,8 @@ class PelEntryRational extends PelEntryLong
     /**
      * Make a new entry that can hold an unsigned rational.
      *
-     * @param
-     *            int the tag which this entry represents. This should
+     * @param int $tag
+     *            the tag which this entry represents. This should
      *            be one of the constants defined in {@link PelTag}, e.g., {@link
      *            PelTag::X_RESOLUTION}, or any other tag which can have format
      *            {@link PelFormat::RATIONAL}.
@@ -98,10 +98,10 @@ class PelEntryRational extends PelEntryLong
      * The rational will be returned as a string with a slash '/'
      * between the numerator and denominator.
      *
-     * @param
-     *            array the rational which will be formatted.
-     * @param
-     *            boolean not used.
+     * @param array $number
+     *            the rational which will be formatted.
+     * @param boolean $brief
+     *            not used.
      * @return string the rational formatted as a string suitable for
      *         display.
      */
@@ -117,8 +117,8 @@ class PelEntryRational extends PelEntryLong
      * e.g., rationals will be returned as 'x/y', ASCII strings will be
      * returned as themselves etc.
      *
-     * @param
-     *            boolean some values can be returned in a long or more
+     * @param boolean $brief
+     *            some values can be returned in a long or more
      *            brief form, and this parameter controls that.
      * @return string the value as text.
      */

--- a/src/PelEntrySLong.php
+++ b/src/PelEntrySLong.php
@@ -56,11 +56,11 @@ class PelEntrySLong extends PelEntryNumber
      * integer argument is given here, or when an array with just a
      * single integer is given.
      *
-     * @param
-     *            int the tag which this entry represents. This
+     * @param int $tag
+     *            the tag which this entry represents. This
      *            should be one of the constants defined in {@link PelTag}
      *            which have format {@link PelFormat::SLONG}.
-     * @param int $value...
+     * @param int $value
      *            the long(s) that this entry will represent
      *            or an array of longs. The argument passed must obey the same
      *            rules as the argument to {@link setValue}, namely that it should
@@ -83,10 +83,10 @@ class PelEntrySLong extends PelEntryNumber
     /**
      * Convert a number into bytes.
      *
-     * @param
-     *            int the number that should be converted.
-     * @param
-     *            PelByteOrder one of {@link PelConvert::LITTLE_ENDIAN} and
+     * @param int $number
+     *            the number that should be converted.
+     * @param boolean $order
+     *            one of {@link PelConvert::LITTLE_ENDIAN} and
      *            {@link PelConvert::BIG_ENDIAN}, specifying the target byte order.
      * @return string bytes representing the number given.
      */

--- a/src/PelEntrySRational.php
+++ b/src/PelEntrySRational.php
@@ -55,12 +55,12 @@ class PelEntrySRational extends PelEntrySLong
     /**
      * Make a new entry that can hold a signed rational.
      *
-     * @param
-     *            int the tag which this entry represents. This should
+     * @param int $tag
+     *            the tag which this entry represents. This should
      *            be one of the constants defined in {@link PelTag}, e.g., {@link
      *            PelTag::SHUTTER_SPEED_VALUE}, or any other tag which can have
      *            format {@link PelFormat::SRATIONAL}.
-     * @param array $value...
+     * @param array $value
      *            the rational(s) that this entry will
      *            represent. The arguments passed must obey the same rules as the
      *            argument to {@link setValue}, namely that each argument should be
@@ -89,10 +89,10 @@ class PelEntrySRational extends PelEntrySLong
      * between the numerator and denominator. Care is taken to display
      * '-1/2' instead of the ugly but mathematically equivalent '1/-2'.
      *
-     * @param
-     *            array the rational which will be formatted.
-     * @param
-     *            boolean not used.
+     * @param array $number
+     *            the rational which will be formatted.
+     * @param boolean $brief
+     *            not used.
      * @return string the rational formatted as a string suitable for
      *         display.
      */
@@ -113,8 +113,8 @@ class PelEntrySRational extends PelEntrySLong
      * e.g., rationals will be returned as 'x/y', ASCII strings will be
      * returned as themselves etc.
      *
-     * @param
-     *            boolean some values can be returned in a long or more
+     * @param boolean $brief
+     *            some values can be returned in a long or more
      *            brief form, and this parameter controls that.
      * @return string the value as text.
      */

--- a/src/PelEntrySShort.php
+++ b/src/PelEntrySShort.php
@@ -101,8 +101,8 @@ class PelEntrySShort extends PelEntryNumber
      * PelTag::METERING_MODE} tag, 'Center-Weighted Average' is
      * returned.
      *
-     * @param
-     *            boolean some values can be returned in a long or more
+     * @param boolean $brief
+     *            some values can be returned in a long or more
      *            brief form, and this parameter controls that.
      * @return string the value as text.
      */

--- a/src/PelEntryShort.php
+++ b/src/PelEntryShort.php
@@ -122,8 +122,8 @@ class PelEntryShort extends PelEntryNumber
      * PelTag::METERING_MODE} tag, 'Center-Weighted Average' is
      * returned.
      *
-     * @param
-     *            boolean some values can be returned in a long or more
+     * @param boolean $brief
+     *            some values can be returned in a long or more
      *            brief form, and this parameter controls that.
      * @return string the value as text.
      */
@@ -495,9 +495,7 @@ class PelEntryShort extends PelEntryNumber
                 if ($this->value[0] == 2 && $this->value[1] == 2) {
                     return 'YCbCr4:2:0';
                 }
-
                 return $this->value[0] . ', ' . $this->value[1];
-                break;
             case PelTag::PHOTOMETRIC_INTERPRETATION:
                 // CC (e->components, 1, v);
                 switch ($this->value[0]) {

--- a/src/PelEntryTime.php
+++ b/src/PelEntryTime.php
@@ -24,24 +24,6 @@
  */
 
 /**
- * Classes used to hold ASCII strings.
- *
- * The classes defined here are to be used for Exif entries holding
- * ASCII strings, such as {@link PelTag::MAKE}, {@link
- * PelTag::SOFTWARE}, and {@link PelTag::DATE_TIME}. For
- * entries holding normal textual ASCII strings the class {@link
- * PelEntryAscii} should be used, but for entries holding
- * timestamps the class {@link PelEntryTime} would be more
- * convenient instead. Copyright information is handled by the {@link
- * PelEntryCopyright} class.
- *
- * @author Martin Geisler <mgeisler@users.sourceforge.net>
- * @license http://www.gnu.org/licenses/gpl.html GNU General Public
- *          License (GPL)
- * @package PEL
- */
-
-/**
  * Class for holding a date and time.
  *
  * This class can hold a timestamp, and it will be used as
@@ -132,7 +114,7 @@ class PelEntryTime extends PelEntryAscii
      */
     public function __construct($tag, $timestamp, $type = self::UNIX_TIMESTAMP)
     {
-        parent::__construct($tag);
+        $this->tag = $tag;
         $this->setValue($timestamp, $type);
     }
 
@@ -147,7 +129,7 @@ class PelEntryTime extends PelEntryAscii
      *            the type of the timestamp. This must be one of
      *            {@link UNIX_TIMESTAMP}, {@link EXIF_STRING}, or
      *            {@link JULIAN_DAY_COUNT}.
-     * @return integer the timestamp held by this entry in the correct form
+     * @return integer|string|false the timestamp held by this entry in the correct form
      *         as indicated by the type argument. For {@link UNIX_TIMESTAMP}
      *         this is an integer counting the number of seconds since January
      *         1st 1970, for {@link EXIF_STRING} this is a string of the form
@@ -270,8 +252,8 @@ class PelEntryTime extends PelEntryAscii
     /**
      * Converts a Julian Day count to a year/month/day triple.
      *
-     * @param
-     *            int the Julian Day count.
+     * @param int $jd
+     *            the Julian Day count.
      * @return array an array with three entries: year, month, day.
      */
     public function convertJdToGregorian($jd)
@@ -307,11 +289,11 @@ class PelEntryTime extends PelEntryAscii
      *
      * @param integer $timestamp
      *            the timestamp.
-     * @return integer the Julian Day count.
+     * @return float the Julian Day count.
      */
     public function convertUnixToJd($timestamp)
     {
-        return (int) (floor($timestamp / 86400) + 2440588);
+        return floor($timestamp / 86400) + 2440588;
     }
 
     /**

--- a/src/PelEntryUndefined.php
+++ b/src/PelEntryUndefined.php
@@ -99,8 +99,8 @@ class PelEntryUndefined extends PelEntry
      *
      * The value will be returned in a format suitable for presentation.
      *
-     * @param
-     *            boolean some values can be returned in a long or more
+     * @param boolean $brief
+     *            some values can be returned in a long or more
      *            brief form, and this parameter controls that.
      * @return string the value as text.
      */

--- a/src/PelEntryUserComment.php
+++ b/src/PelEntryUserComment.php
@@ -24,21 +24,6 @@
  */
 
 /**
- * Classes used to hold data for Exif tags of format undefined.
- *
- * This file contains the base class {@link PelEntryUndefined} and
- * the subclasses {@link PelEntryUserComment} which should be used
- * to manage the {@link PelTag::USER_COMMENT} tag, and {@link
- * PelEntryVersion} which is used to manage entries with version
- * information.
- *
- * @author Martin Geisler <mgeisler@users.sourceforge.net>
- * @license http://www.gnu.org/licenses/gpl.html GNU General Public
- *          License (GPL)
- * @package PEL
- */
-
-/**
  * Class for a user comment.
  *
  * This class is used to hold user comments, which can come in several
@@ -89,10 +74,10 @@ class PelEntryUserComment extends PelEntryUndefined
     /**
      * Make a new entry for holding a user comment.
      *
-     * @param
-     *            string the new user comment.
-     * @param
-     *            string the encoding of the comment. This should be either
+     * @param string $comment
+     *            the new user comment.
+     * @param string $encoding
+     *            the encoding of the comment. This should be either
      *            'ASCII', 'JIS', 'Unicode', or the empty string specifying an
      *            undefined encoding.
      */
@@ -105,10 +90,10 @@ class PelEntryUserComment extends PelEntryUndefined
     /**
      * Set the user comment.
      *
-     * @param
-     *            string the new user comment.
-     * @param
-     *            string the encoding of the comment. This should be either
+     * @param string $comment
+     *            the new user comment.
+     * @param string $encoding
+     *            the encoding of the comment. This should be either
      *            'ASCII', 'JIS', 'Unicode', or the empty string specifying an
      *            unknown encoding.
      */

--- a/src/PelEntryVersion.php
+++ b/src/PelEntryVersion.php
@@ -24,21 +24,6 @@
  */
 
 /**
- * Classes used to hold data for Exif tags of format undefined.
- *
- * This file contains the base class {@link PelEntryUndefined} and
- * the subclasses {@link PelEntryUserComment} which should be used
- * to manage the {@link PelTag::USER_COMMENT} tag, and {@link
- * PelEntryVersion} which is used to manage entries with version
- * information.
- *
- * @author Martin Geisler <mgeisler@users.sourceforge.net>
- * @license http://www.gnu.org/licenses/gpl.html GNU General Public
- *          License (GPL)
- * @package PEL
- */
-
-/**
  * Class to hold version information.
  *
  * There are three Exif entries that hold version information: the

--- a/src/PelEntryWindowsString.php
+++ b/src/PelEntryWindowsString.php
@@ -24,18 +24,6 @@
  */
 
 /**
- * Classes used to hold bytes, both signed and unsigned.
- * The {@link
- * PelEntryWindowsString} class is used to manipulate strings in the
- * format Windows XP needs.
- *
- * @author Martin Geisler <mgeisler@users.sourceforge.net>
- * @license http://www.gnu.org/licenses/gpl.html GNU General Public
- *          License (GPL)
- * @package PEL
- */
-
-/**
  * Class used to manipulate strings in the format Windows XP uses.
  *
  * When examining the file properties of an image in Windows XP one

--- a/src/PelExif.php
+++ b/src/PelExif.php
@@ -24,15 +24,6 @@
  */
 
 /**
- * Classes for dealing with Exif data.
- *
- * @author Martin Geisler <mgeisler@users.sourceforge.net>
- * @license http://www.gnu.org/licenses/gpl.html GNU General Public
- *          License (GPL)
- * @package PEL
- */
-
-/**
  * Class representing Exif data.
  *
  * Exif data resides as {@link PelJpegContent data} and consists of a

--- a/src/PelFormat.php
+++ b/src/PelFormat.php
@@ -204,9 +204,8 @@ class PelFormat
     {
         if (array_key_exists($type, self::$formatName)) {
             return self::$formatName[$type];
-        } else {
-            return Pel::fmt('Unknown format: 0x%X', $type);
         }
+        throw new PelIllegalFormatException($type);
     }
 
     /**
@@ -221,8 +220,7 @@ class PelFormat
     {
         if (array_key_exists($type, self::$formatLength)) {
             return self::$formatLength[$type];
-        } else {
-            return Pel::fmt('Unknown format: 0x%X', $type);
         }
+        throw new PelIllegalFormatException($type);
     }
 }

--- a/src/PelIllegalFormatException.php
+++ b/src/PelIllegalFormatException.php
@@ -5,8 +5,7 @@
  * A library with support for reading and
  * writing all Exif headers in JPEG and TIFF images using PHP.
  *
- * Copyright (C) 2004, 2006 Martin Geisler.
- * Copyright (C) 2017 Johannes Weberhofer
+ * Copyright (C) 2004, 2005, 2006 Martin Geisler.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,24 +22,30 @@
  * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
  * Boston, MA 02110-1301 USA
  */
-namespace Pel\Test;
 
-use PHPUnit\Framework\TestCase;
-use lsolesen\pel\PelEntryUserComment;
+/**
+ * Exception indicating that an unexpected format was found.
+ *
+ * The documentation for each tag in {@link PelTag} will detail any
+ * constrains.
+ *
+ * @author Martin Geisler <mgeisler@users.sourceforge.net>
+ * @package PEL
+ * @subpackage Exception
+ */
+namespace lsolesen\pel;
 
-class PelEntryUserCommentTest extends TestCase
+class PelIllegalFormatException extends PelException
 {
 
-    public function testUsercomment()
+    /**
+     * Construct a new exception indicating an illegal format.
+     *
+     * @param int $type
+     *            the type of IFD.
+     */
+    public function __construct($type)
     {
-        $entry = new PelEntryUserComment();
-        $this->assertEquals($entry->getComponents(), 8);
-        $this->assertEquals($entry->getValue(), '');
-        $this->assertEquals($entry->getEncoding(), 'ASCII');
-
-        $entry->setValue('Hello!');
-        $this->assertEquals($entry->getComponents(), 14);
-        $this->assertEquals($entry->getValue(), 'Hello!');
-        $this->assertEquals($entry->getEncoding(), 'ASCII');
+        parent::__construct('Unknown format: 0x%X', $type);
     }
 }

--- a/src/PelInvalidArgumentException.php
+++ b/src/PelInvalidArgumentException.php
@@ -41,8 +41,6 @@
  */
 namespace lsolesen\pel;
 
-use lsolesen\pel\PelException;
-
 class PelInvalidArgumentException extends PelException
 {
 }

--- a/src/PelInvalidDataException.php
+++ b/src/PelInvalidDataException.php
@@ -41,8 +41,6 @@
  */
 namespace lsolesen\pel;
 
-use lsolesen\pel\PelException;
-
 class PelInvalidDataException extends PelException
 {
 }

--- a/src/PelJpeg.php
+++ b/src/PelJpeg.php
@@ -397,10 +397,7 @@ class PelJpeg
     public function getICC()
     {
         $icc = $this->getSection(PelJpegMarker::APP2);
-        if ($icc instanceof PelJpegContent) {
-            return $icc;
-        }
-        return null;
+        return $icc;
     }
 
     /**

--- a/src/PelJpegContent.php
+++ b/src/PelJpegContent.php
@@ -47,8 +47,6 @@
  */
 namespace lsolesen\pel;
 
-use lsolesen\pel\PelDataWindow;
-
 class PelJpegContent
 {
 

--- a/src/PelTiff.php
+++ b/src/PelTiff.php
@@ -114,9 +114,8 @@ class PelTiff
      * will be built. If the data cannot be parsed correctly, a {@link
      * PelInvalidDataException} is thrown, explaining the problem.
      *
-     * @param
-     *            d
-     *            PelDataWindow the data from which the object will be
+     * @param PelDataWindow $d
+     *            the data from which the object will be
      *            constructed. This should be valid TIFF data, coming either
      *            directly from a TIFF image or from the Exif data in a JPEG image.
      */
@@ -248,8 +247,8 @@ class PelTiff
     /**
      * Save the TIFF object as a TIFF image in a file.
      *
-     * @param
-     *            string the filename to save in. An existing file with the
+     * @param string $filename
+     *            the filename to save in. An existing file with the
      *            same name will be overwritten!
      * @return integer|FALSE The number of bytes that were written to the
      *         file, or FALSE on failure.

--- a/src/PelWrongComponentCountException.php
+++ b/src/PelWrongComponentCountException.php
@@ -24,22 +24,6 @@
  */
 
 /**
- * Classes for dealing with Exif entries.
- *
- * This file defines two exception classes and the abstract class
- * {@link PelEntry} which provides the basic methods that all Exif
- * entries will have. All Exif entries will be represented by
- * descendants of the {@link PelEntry} class --- the class itself is
- * abstract and so it cannot be instantiated.
- *
- * @author Martin Geisler <mgeisler@users.sourceforge.net>
- * @license http://www.gnu.org/licenses/gpl.html GNU General Public
- *          License (GPL)
- * @package PEL
- */
-namespace lsolesen\pel;
-
-/**
  * Exception indicating that an unexpected number of components was
  * found.
  *
@@ -52,6 +36,10 @@ namespace lsolesen\pel;
  * @package PEL
  * @subpackage Exception
  */
+namespace lsolesen\pel;
+
+use lsolesen\pel\PelTag;
+
 class PelWrongComponentCountException extends \lsolesen\pel\PelEntryException
 {
 

--- a/test/BrokenImagesTest.php
+++ b/test/BrokenImagesTest.php
@@ -23,8 +23,9 @@
  */
 namespace Pel\Test;
 
-use lsolesen\pel\PelJpeg;
 use PHPUnit\Framework\TestCase;
+use lsolesen\pel\PelIllegalFormatException;
+use lsolesen\pel\PelJpeg;
 
 class BrokenImagesTest extends TestCase
 {
@@ -49,6 +50,7 @@ class BrokenImagesTest extends TestCase
 
     public function testInvalidIfd()
     {
+        $this->expectException(PelIllegalFormatException::class) ;
         $jpeg = new PelJpeg(dirname(__FILE__) . '/broken_images/gh-156.jpg');
         $this->assertInstanceOf('\lsolesen\pel\PelJpeg', $jpeg);
     }

--- a/test/Bug3017880Test.php
+++ b/test/Bug3017880Test.php
@@ -24,6 +24,7 @@
  */
 namespace Pel\Test;
 
+use Exception;
 use lsolesen\pel\PelJpeg;
 use lsolesen\pel\PelExif;
 use lsolesen\pel\PelTiff;
@@ -40,7 +41,6 @@ class Bug3017880Test extends TestCase
         $filename = dirname(__FILE__) . '/images/bug3017880.jpg';
         try {
             $exif = null;
-            $success = 1; // return true by default, as this function may not resave the file, but it's still success
             $resave_file = 0;
             $jpeg = new PelJpeg($filename);
             $this->assertInstanceOf('\lsolesen\pel\PelJpeg', $jpeg);

--- a/test/GH16Test.php
+++ b/test/GH16Test.php
@@ -23,18 +23,21 @@
  */
 namespace Pel\Test;
 
-use lsolesen\pel\PelDataWindow;
-use lsolesen\pel\PelJpeg;
-use lsolesen\pel\PelEntryWindowsString;
-use lsolesen\pel\PelTag;
 use PHPUnit\Framework\TestCase;
+use lsolesen\pel\PelDataWindow;
+use lsolesen\pel\PelEntryWindowsString;
+use lsolesen\pel\PelExif;
+use lsolesen\pel\PelIfd;
+use lsolesen\pel\PelJpeg;
+use lsolesen\pel\PelTag;
+use lsolesen\pel\PelTiff;
 
 class GH16Test extends TestCase
 {
 
     protected $file;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->file = dirname(__FILE__) . '/images/gh-16-tmp.jpg';
         $file = dirname(__FILE__) . '/images/gh-16.jpg';

--- a/test/GH21Test.php
+++ b/test/GH21Test.php
@@ -49,13 +49,18 @@ class GH21Test extends TestCase
         $input_jpeg = new PelJpeg($this->file);
 
         $original = ImageCreateFromString($input_jpeg->getBytes());
+
+        $this->assertNotFalse($original, 'New image must not be false');
+
         $original_w = ImagesX($original);
         $original_h = ImagesY($original);
 
-        $scaled_w = $original_w * $scale;
-        $scaled_h = $original_h * $scale;
+        $scaled_w = (int) ($original_w * $scale);
+        $scaled_h = (int) ($original_h * $scale);
 
         $scaled = ImageCreateTrueColor($scaled_w, $scaled_h);
+        $this->assertNotFalse($scaled, 'Resized image must not be false');
+
         ImageCopyResampled($scaled, $original, 0, 0, 0, 0, $scaled_w, $scaled_h, $original_w, $original_h);
 
         $output_jpeg = new PelJpeg($scaled);

--- a/test/GH77Test.php
+++ b/test/GH77Test.php
@@ -24,12 +24,9 @@
  */
 namespace Pel\Test;
 
-use lsolesen\pel\PelDataWindow;
-use lsolesen\pel\PelJpeg;
-use lsolesen\pel\PelTiff;
-use lsolesen\pel\Pel;
-use lsolesen\pel\PelTag;
 use PHPUnit\Framework\TestCase;
+use lsolesen\pel\PelJpeg;
+use lsolesen\pel\PelTag;
 
 class GH77Test extends TestCase
 {

--- a/test/IfdTest.php
+++ b/test/IfdTest.php
@@ -24,11 +24,11 @@
  */
 namespace Pel\Test;
 
-use lsolesen\pel\PelIfd;
-use lsolesen\pel\PelEntryAscii;
-use lsolesen\pel\PelTag;
-use lsolesen\pel\PelEntryTime;
 use PHPUnit\Framework\TestCase;
+use lsolesen\pel\PelEntryAscii;
+use lsolesen\pel\PelEntryTime;
+use lsolesen\pel\PelIfd;
+use lsolesen\pel\PelTag;
 
 class IfdTest extends TestCase
 {

--- a/test/MisplacedExifTest.php
+++ b/test/MisplacedExifTest.php
@@ -23,11 +23,11 @@
  */
 namespace Pel\Test;
 
-use lsolesen\pel\Pel;
-use lsolesen\pel\PelJpeg;
-use lsolesen\pel\PelExif;
-use lsolesen\pel\PelJpegMarker;
 use PHPUnit\Framework\TestCase;
+use lsolesen\pel\Pel;
+use lsolesen\pel\PelExif;
+use lsolesen\pel\PelJpeg;
+use lsolesen\pel\PelJpegMarker;
 
 class MisplacedExifTest extends TestCase
 {

--- a/test/NoExifTest.php
+++ b/test/NoExifTest.php
@@ -23,9 +23,9 @@
  */
 namespace Pel\Test;
 
+use PHPUnit\Framework\TestCase;
 use lsolesen\pel\Pel;
 use lsolesen\pel\PelJpeg;
-use PHPUnit\Framework\TestCase;
 
 class NoExifTest extends TestCase
 {

--- a/test/NumberSByteTest.php
+++ b/test/NumberSByteTest.php
@@ -29,10 +29,6 @@ use lsolesen\pel\PelEntrySByte;
 class NumberSByteTest extends NumberTestCase
 {
 
-    /**
-     *
-     * {@inheritdoc}
-     */
     public function setUp(): void
     {
         parent::setUp();

--- a/test/NumberSLongTest.php
+++ b/test/NumberSLongTest.php
@@ -29,10 +29,6 @@ use lsolesen\pel\PelEntrySLong;
 class NumberSLongTest extends NumberTestCase
 {
 
-    /**
-     *
-     * {@inheritdoc}
-     */
     public function setUp(): void
     {
         parent::setUp();

--- a/test/NumberSShortTest.php
+++ b/test/NumberSShortTest.php
@@ -29,10 +29,6 @@ use lsolesen\pel\PelEntrySShort;
 class NumberSShortTest extends NumberTestCase
 {
 
-    /**
-     *
-     * {@inheritdoc}
-     */
     public function setUp(): void
     {
         parent::setUp();

--- a/test/NumberTestCase.php
+++ b/test/NumberTestCase.php
@@ -24,9 +24,9 @@
  */
 namespace Pel\Test;
 
+use PHPUnit\Framework\TestCase;
 use lsolesen\pel\Pel;
 use lsolesen\pel\PelOverflowException;
-use PHPUnit\Framework\TestCase;
 
 abstract class NumberTestCase extends TestCase
 {

--- a/test/PelEntryUndefinedTest.php
+++ b/test/PelEntryUndefinedTest.php
@@ -25,11 +25,11 @@
  */
 namespace Pel\Test;
 
+use PHPUnit\Framework\TestCase;
+use lsolesen\pel\PelConvert;
 use lsolesen\pel\PelEntryUndefined;
 use lsolesen\pel\PelEntryUserComment;
 use lsolesen\pel\PelEntryVersion;
-use lsolesen\pel\PelConvert;
-use PHPUnit\Framework\TestCase;
 
 class PelEntryUndefinedTest extends TestCase
 {

--- a/test/PelEntryVersionTest.php
+++ b/test/PelEntryVersionTest.php
@@ -25,9 +25,9 @@
  */
 namespace Pel\Test;
 
-use lsolesen\pel\PelEntryVersion;
-use lsolesen\pel\PelConvert;
 use PHPUnit\Framework\TestCase;
+use lsolesen\pel\PelConvert;
+use lsolesen\pel\PelEntryVersion;
 
 class PelEntryVersionTest extends TestCase
 {

--- a/test/PelEntryWindowsStringTest.php
+++ b/test/PelEntryWindowsStringTest.php
@@ -25,10 +25,10 @@
  */
 namespace Pel\Test;
 
+use PHPUnit\Framework\TestCase;
 use lsolesen\pel\PelConvert;
 use lsolesen\pel\PelEntryWindowsString;
 use lsolesen\pel\PelTag;
-use PHPUnit\Framework\TestCase;
 
 class PelEntryWindowsStringTest extends TestCase
 {

--- a/test/PelFormatTest.php
+++ b/test/PelFormatTest.php
@@ -26,8 +26,8 @@
 namespace Pel\Test;
 
 use PHPUnit\Framework\TestCase;
-use lsolesen\pel\Pel;
 use lsolesen\pel\PelFormat;
+use lsolesen\pel\PelIllegalFormatException;
 
 class PelFormatTest extends TestCase
 {
@@ -38,7 +38,8 @@ class PelFormatTest extends TestCase
         $this->assertEquals($pelFormat::getName(PelFormat::ASCII), 'Ascii');
         $this->assertEquals($pelFormat::getName(PelFormat::FLOAT), 'Float');
         $this->assertEquals($pelFormat::getName(PelFormat::UNDEFINED), 'Undefined');
-        $this->assertEquals($pelFormat::getName(100), Pel::fmt('Unknown format: 0x%X', 100));
+        $this->expectException(PelIllegalFormatException::class);
+        $pelFormat::getName(100);
     }
 
     public function testDescriptions()
@@ -47,6 +48,7 @@ class PelFormatTest extends TestCase
         $this->assertEquals($pelFormat::getSize(PelFormat::ASCII), 1);
         $this->assertEquals($pelFormat::getSize(PelFormat::FLOAT), 4);
         $this->assertEquals($pelFormat::getSize(PelFormat::UNDEFINED), 1);
-        $this->assertEquals($pelFormat::getSize(100), Pel::fmt('Unknown format: 0x%X', 100));
+        $this->expectException(PelIllegalFormatException::class);
+        $pelFormat::getSize(100);
     }
 }

--- a/test/PelJpegMarkerTest.php
+++ b/test/PelJpegMarkerTest.php
@@ -26,9 +26,9 @@
 namespace Pel\Test;
 
 use PHPUnit\Framework\TestCase;
-use lsolesen\pel\PelJpegMarker;
 use lsolesen\pel\Pel;
 use lsolesen\pel\PelJpegInvalidMarkerException;
+use lsolesen\pel\PelJpegMarker;
 
 class PelJpegMarkerTest extends TestCase
 {

--- a/test/PelTagTest.php
+++ b/test/PelTagTest.php
@@ -25,8 +25,8 @@
  */
 namespace Pel\Test;
 
-use lsolesen\pel\PelIfd;
 use PHPUnit\Framework\TestCase;
+use lsolesen\pel\PelIfd;
 use lsolesen\pel\PelTag;
 
 class PelTagTest extends TestCase

--- a/test/README.md
+++ b/test/README.md
@@ -37,11 +37,9 @@ phpunit
 
 ## Failing Tests
 
-Should one or more of the tests fail, then first ensure that
-SimpleTest is placed correctly so that run-tests.php can find it. If
-everything seems correct, then please report the error to the PEL
-developers:
+Should one or more of the tests fail, please report the error to 
+the PEL developers:
 
-  https://github.com/lsolesen/pel/issues
+  https://github.com/pel/pel/issues
 
 Remember to include all the output in your bug report.

--- a/test/Tags1Test.php
+++ b/test/Tags1Test.php
@@ -21,11 +21,11 @@
  * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
  * Boston, MA 02110-1301 USA
  */
-namespace Pel\Test\imagetests;
+namespace Pel\Test;
 
+use PHPUnit\Framework\TestCase;
 use lsolesen\pel\Pel;
 use lsolesen\pel\PelJpeg;
-use PHPUnit\Framework\TestCase;
 
 class Tags1Test extends TestCase
 {

--- a/test/imagetests/CanonEos650dTest.php
+++ b/test/imagetests/CanonEos650dTest.php
@@ -23,9 +23,9 @@
  */
 namespace Pel\Test\imagetests;
 
+use PHPUnit\Framework\TestCase;
 use lsolesen\pel\Pel;
 use lsolesen\pel\PelJpeg;
-use PHPUnit\Framework\TestCase;
 
 class CanonEos650dTest extends TestCase
 {
@@ -47,48 +47,48 @@ class CanonEos650dTest extends TestCase
         $this->assertInstanceOf('lsolesen\pel\PelIfd', $ifd0);
 
         /* Start of IDF $ifd0. */
-        $this->assertEquals(count($ifd0->getEntries()), 9);
+        $this->assertEquals(9, count($ifd0->getEntries()));
 
         $entry = $ifd0->getEntry(271); // Make
         $this->assertInstanceOf('lsolesen\pel\PelEntryAscii', $entry);
-        $this->assertEquals($entry->getValue(), 'Canon');
-        $this->assertEquals($entry->getText(), 'Canon');
+        $this->assertEquals('Canon', $entry->getValue());
+        $this->assertEquals('Canon', $entry->getText());
 
         $entry = $ifd0->getEntry(272); // Model
         $this->assertInstanceOf('lsolesen\pel\PelEntryAscii', $entry);
-        $this->assertEquals($entry->getValue(), 'Canon EOS 650D');
-        $this->assertEquals($entry->getText(), 'Canon EOS 650D');
+        $this->assertEquals('Canon EOS 650D', $entry->getValue());
+        $this->assertEquals('Canon EOS 650D', $entry->getText());
 
         $entry = $ifd0->getEntry(274); // Orientation
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 1);
-        $this->assertEquals($entry->getText(), 'top - left');
+        $this->assertEquals(1, $entry->getValue());
+        $this->assertEquals('top - left', $entry->getText());
 
         $entry = $ifd0->getEntry(282); // XResolution
         $this->assertInstanceOf('lsolesen\pel\PelEntryRational', $entry);
-        $this->assertEquals($entry->getValue(), [
+        $this->assertEquals([
             0 => 72,
             1 => 1
-        ]);
-        $this->assertEquals($entry->getText(), '72/1');
+        ], $entry->getValue());
+        $this->assertEquals('72/1', $entry->getText());
 
         $entry = $ifd0->getEntry(283); // YResolution
         $this->assertInstanceOf('lsolesen\pel\PelEntryRational', $entry);
-        $this->assertEquals($entry->getValue(), [
+        $this->assertEquals([
             0 => 72,
             1 => 1
-        ]);
+        ], $entry->getValue());
         $this->assertEquals($entry->getText(), '72/1');
 
         $entry = $ifd0->getEntry(296); // ResolutionUnit
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 2);
-        $this->assertEquals($entry->getText(), 'Inch');
+        $this->assertEquals(2, $entry->getValue());
+        $this->assertEquals('Inch', $entry->getText());
 
         $entry = $ifd0->getEntry(306); // DateTime
         $this->assertInstanceOf('lsolesen\pel\PelEntryTime', $entry);
-        $this->assertEquals($entry->getValue(), 1509974253);
-        $this->assertEquals($entry->getText(), '2017:11:06 13:17:33');
+        $this->assertEquals(1509974253, $entry->getValue());
+        $this->assertEquals('2017:11:06 13:17:33', $entry->getText());
 
         /* Sub IFDs of $ifd0. */
         $this->assertEquals(count($ifd0->getSubIfds()), 2);
@@ -100,39 +100,39 @@ class CanonEos650dTest extends TestCase
 
         $entry = $ifd0_0->getEntry(33434); // ExposureTime
         $this->assertInstanceOf('lsolesen\pel\PelEntryRational', $entry);
-        $this->assertEquals($entry->getValue(), [
+        $this->assertEquals([
             0 => 1,
             1 => 800
-        ]);
-        $this->assertEquals($entry->getText(), '1/800 sec.');
+        ], $entry->getValue());
+        $this->assertEquals('1/800 sec.', $entry->getText());
 
         $entry = $ifd0_0->getEntry(33437); // FNumber
         $this->assertInstanceOf('lsolesen\pel\PelEntryRational', $entry);
-        $this->assertEquals($entry->getValue(), [
+        $this->assertEquals([
             0 => 63,
             1 => 10
-        ]);
-        $this->assertEquals($entry->getText(), 'f/6.3');
+        ], $entry->getValue());
+        $this->assertEquals('f/6.3', $entry->getText());
 
         $entry = $ifd0_0->getEntry(36864); // ExifVersion
         $this->assertInstanceOf('lsolesen\pel\PelEntryVersion', $entry);
-        $this->assertEquals($entry->getValue(), 2.3);
-        $this->assertEquals($entry->getText(), 'Exif Version 2.3');
+        $this->assertEquals(2.3, $entry->getValue());
+        $this->assertEquals('Exif Version 2.3', $entry->getText());
 
         $entry = $ifd0_0->getEntry(36867); // DateTimeOriginal
         $this->assertInstanceOf('lsolesen\pel\PelEntryTime', $entry);
-        $this->assertEquals($entry->getValue(), 1497623444);
-        $this->assertEquals($entry->getText(), '2017:06:16 14:30:44');
+        $this->assertEquals(1497623444, $entry->getValue());
+        $this->assertEquals('2017:06:16 14:30:44', $entry->getText());
 
         $entry = $ifd0_0->getEntry(36868); // DateTimeDigitized
         $this->assertInstanceOf('lsolesen\pel\PelEntryTime', $entry);
-        $this->assertEquals($entry->getValue(), 1497623444);
-        $this->assertEquals($entry->getText(), '2017:06:16 14:30:44');
+        $this->assertEquals(1497623444, $entry->getValue());
+        $this->assertEquals('2017:06:16 14:30:44', $entry->getText());
 
         $entry = $ifd0_0->getEntry(37121); // ComponentsConfiguration
         $this->assertInstanceOf('lsolesen\pel\PelEntryUndefined', $entry);
-        $this->assertEquals($entry->getValue(), "\x01\x02\x03\0");
-        $this->assertEquals($entry->getText(), 'Y Cb Cr -');
+        $this->assertEquals("\x01\x02\x03\0", $entry->getValue());
+        $this->assertEquals('Y Cb Cr -', $entry->getText());
 
         $entry = $ifd0_0->getEntry(37378); // ApertureValue
         $this->assertInstanceOf('lsolesen\pel\PelEntryRational', $entry);
@@ -144,29 +144,29 @@ class CanonEos650dTest extends TestCase
 
         $entry = $ifd0_0->getEntry(37380); // ExposureBiasValue
         $this->assertInstanceOf('lsolesen\pel\PelEntrySRational', $entry);
-        $this->assertEquals($entry->getValue(), [
+        $this->assertEquals([
             0 => 0,
             1 => 1
-        ]);
-        $this->assertEquals($entry->getText(), '0.0');
+        ], $entry->getValue());
+        $this->assertEquals('0.0', $entry->getText());
 
         $entry = $ifd0_0->getEntry(37383); // MeteringMode
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 5);
-        $this->assertEquals($entry->getText(), 'Pattern');
+        $this->assertEquals(5, $entry->getValue());
+        $this->assertEquals('Pattern', $entry->getText());
 
         $entry = $ifd0_0->getEntry(37385); // Flash
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 16);
-        $this->assertEquals($entry->getText(), 'Flash did not fire, compulsory flash mode.');
+        $this->assertEquals(16, $entry->getValue());
+        $this->assertEquals('Flash did not fire, compulsory flash mode.', $entry->getText());
 
         $entry = $ifd0_0->getEntry(37386); // FocalLength
         $this->assertInstanceOf('lsolesen\pel\PelEntryRational', $entry);
-        $this->assertEquals($entry->getValue(), [
+        $this->assertEquals([
             0 => 600,
             1 => 1
-        ]);
-        $this->assertEquals($entry->getText(), '600.0 mm');
+        ], $entry->getValue());
+        $this->assertEquals('600.0 mm', $entry->getText());
 
         $entry = $ifd0_0->getEntry(37500); // MakerNote
         $this->assertNull($entry);
@@ -175,45 +175,45 @@ class CanonEos650dTest extends TestCase
         $this->assertInstanceOf('lsolesen\pel\PelEntryUserComment', $entry);
 
         $expected = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
-        $this->assertEquals($entry->getValue(), $expected);
+        $this->assertEquals($expected, $entry->getValue());
 
         $expected = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
-        $this->assertEquals($entry->getText(), $expected);
+        $this->assertEquals($expected, $entry->getText());
 
         $entry = $ifd0_0->getEntry(40960); // FlashPixVersion
         $this->assertInstanceOf('lsolesen\pel\PelEntryVersion', $entry);
-        $this->assertEquals($entry->getValue(), 1);
-        $this->assertEquals($entry->getText(), 'FlashPix Version 1.0');
+        $this->assertEquals(1, $entry->getValue());
+        $this->assertEquals('FlashPix Version 1.0', $entry->getText());
 
         $entry = $ifd0_0->getEntry(40961); // ColorSpace
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 1);
-        $this->assertEquals($entry->getText(), 'sRGB');
+        $this->assertEquals(1, $entry->getValue());
+        $this->assertEquals('sRGB', $entry->getText());
 
         $entry = $ifd0_0->getEntry(41488); // FocalPlaneResolutionUnit
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 2);
-        $this->assertEquals($entry->getText(), 'Inch');
+        $this->assertEquals(2, $entry->getValue());
+        $this->assertEquals('Inch', $entry->getText());
 
         $entry = $ifd0_0->getEntry(41985); // CustomRendered
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 0);
-        $this->assertEquals($entry->getText(), 'Normal process');
+        $this->assertEquals(0, $entry->getValue());
+        $this->assertEquals('Normal process', $entry->getText());
 
         $entry = $ifd0_0->getEntry(41986); // ExposureMode
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 0);
-        $this->assertEquals($entry->getText(), 'Auto exposure');
+        $this->assertEquals(0, $entry->getValue());
+        $this->assertEquals('Auto exposure', $entry->getText());
 
         $entry = $ifd0_0->getEntry(41987); // WhiteBalance
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 0);
-        $this->assertEquals($entry->getText(), 'Auto white balance');
+        $this->assertEquals(0, $entry->getValue());
+        $this->assertEquals('Auto white balance', $entry->getText());
 
         $entry = $ifd0_0->getEntry(41990); // SceneCaptureType
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 0);
-        $this->assertEquals($entry->getText(), 'Standard');
+        $this->assertEquals(0, $entry->getValue(), 0);
+        $this->assertEquals('Standard', $entry->getText());
 
         /* Sub IFDs of $ifd0_0. */
         $this->assertEquals(count($ifd0_0->getSubIfds()), 2);
@@ -221,36 +221,36 @@ class CanonEos650dTest extends TestCase
         $this->assertInstanceOf('lsolesen\pel\PelIfd', $ifd0_0_0);
 
         /* Start of IDF $ifd0_0_0. */
-        $this->assertEquals(count($ifd0_0_0->getEntries()), 2);
+        $this->assertEquals(2, count($ifd0_0_0->getEntries()));
 
         $entry = $ifd0_0_0->getEntry(1); // InteroperabilityIndex
         $this->assertInstanceOf('lsolesen\pel\PelEntryAscii', $entry);
-        $this->assertEquals($entry->getValue(), 'R98');
-        $this->assertEquals($entry->getText(), 'R98');
+        $this->assertEquals('R98', $entry->getValue());
+        $this->assertEquals('R98', $entry->getText());
 
         $entry = $ifd0_0_0->getEntry(2); // InteroperabilityVersion
         $this->assertInstanceOf('lsolesen\pel\PelEntryVersion', $entry);
-        $this->assertEquals($entry->getValue(), 1);
-        $this->assertEquals($entry->getText(), 'Interoperability Version 1.0');
+        $this->assertEquals(1, $entry->getValue());
+        $this->assertEquals('Interoperability Version 1.0', $entry->getText());
 
         /* Sub IFDs of $ifd0_0_0. */
-        $this->assertEquals(count($ifd0_0_0->getSubIfds()), 0);
+        $this->assertEquals(0, count($ifd0_0_0->getSubIfds()));
 
-        $this->assertEquals($ifd0_0_0->getThumbnailData(), '');
+        $this->assertEquals('', $ifd0_0_0->getThumbnailData());
 
         /* Next IFD. */
         $ifd0_0_1 = $ifd0_0_0->getNextIfd();
         $this->assertNull($ifd0_0_1);
         /* End of IFD $ifd0_0_0. */
 
-        $this->assertEquals($ifd0_0->getThumbnailData(), '');
+        $this->assertEquals('', $ifd0_0->getThumbnailData());
 
         /* Next IFD. */
         $ifd0_1 = $ifd0_0->getNextIfd();
         $this->assertNull($ifd0_1);
         /* End of IFD $ifd0_0. */
 
-        $this->assertEquals($ifd0->getThumbnailData(), '');
+        $this->assertEquals('', $ifd0->getThumbnailData());
 
         /* Next IFD. */
         $ifd1 = $ifd0->getNextIfd();
@@ -262,32 +262,32 @@ class CanonEos650dTest extends TestCase
 
         $entry = $ifd1->getEntry(259); // Compression
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 0);
-        $this->assertEquals($entry->getText(), '0');
+        $this->assertEquals(0, $entry->getValue());
+        $this->assertEquals('0', $entry->getText());
 
         $entry = $ifd1->getEntry(282); // XResolution
         $this->assertInstanceOf('lsolesen\pel\PelEntryRational', $entry);
-        $this->assertEquals($entry->getValue(), [
+        $this->assertEquals([
             0 => 72,
             1 => 1
-        ]);
-        $this->assertEquals($entry->getText(), '72/1');
+        ], $entry->getValue());
+        $this->assertEquals('72/1', $entry->getText());
 
         $entry = $ifd1->getEntry(283); // YResolution
         $this->assertInstanceOf('lsolesen\pel\PelEntryRational', $entry);
-        $this->assertEquals($entry->getValue(), [
+        $this->assertEquals([
             0 => 72,
             1 => 1
-        ]);
-        $this->assertEquals($entry->getText(), '72/1');
+        ], $entry->getValue());
+        $this->assertEquals('72/1', $entry->getText());
 
         $entry = $ifd1->getEntry(296); // ResolutionUnit
         $this->assertInstanceOf('lsolesen\pel\PelEntryShort', $entry);
-        $this->assertEquals($entry->getValue(), 2);
-        $this->assertEquals($entry->getText(), 'Inch');
+        $this->assertEquals(2, $entry->getValue());
+        $this->assertEquals('Inch', $entry->getText());
 
         /* Sub IFDs of $ifd1. */
-        $this->assertEquals(count($ifd1->getSubIfds()), 0);
+        $this->assertEquals(0, count($ifd1->getSubIfds()));
 
         $thumb_data = file_get_contents(dirname(__FILE__) . '/canon-eos-650d-thumb.jpg');
         $this->assertEquals($ifd1->getThumbnailData(), $thumb_data);
@@ -303,33 +303,33 @@ class CanonEos650dTest extends TestCase
 
         $entry = $ifd0_mn->getEntry(6); // ImageType
         $this->assertInstanceOf('lsolesen\pel\PelEntryAscii', $entry);
-        $this->assertEquals($entry->getValue(), 'Canon EOS 650D');
+        $this->assertEquals('Canon EOS 650D', $entry->getValue());
 
         $entry = $ifd0_mn->getEntry(7); // FirmwareVersion
         $this->assertInstanceOf('lsolesen\pel\PelEntryAscii', $entry);
-        $this->assertEquals($entry->getValue(), 'Firmware Version 1.0.4');
+        $this->assertEquals('Firmware Version 1.0.4', $entry->getValue());
 
         /* Start of IDF $ifd0_mn_cs. */
         $ifd0_mn_cs = $ifd0_mn->getSubIfd(6); // CameraSettings
         $this->assertInstanceOf('lsolesen\pel\PelIfd', $ifd0_mn_cs);
-        $this->assertEquals(count($ifd0_mn_cs->getEntries()), 37);
+        $this->assertEquals(37, count($ifd0_mn_cs->getEntries()));
 
         $entry = $ifd0_mn_cs->getEntry(1); // MacroMode
         $this->assertInstanceOf('lsolesen\pel\PelEntrySShort', $entry);
-        $this->assertEquals($entry->getValue(), '2');
-        $this->assertEquals($entry->getText(), 'Normal');
+        $this->assertEquals('2', $entry->getValue());
+        $this->assertEquals('Normal', $entry->getText());
 
         $entry = $ifd0_mn_cs->getEntry(9); // RecordMode
         $this->assertInstanceOf('lsolesen\pel\PelEntrySShort', $entry);
-        $this->assertEquals($entry->getValue(), '6');
-        $this->assertEquals($entry->getText(), 'CR2');
+        $this->assertEquals('6', $entry->getValue());
+        $this->assertEquals('CR2', $entry->getText());
 
         $entry = $ifd0_mn_cs->getEntry(22); // LensModel
         $this->assertInstanceOf('lsolesen\pel\PelEntrySShort', $entry);
-        $this->assertEquals($entry->getValue(), 747);
+        $this->assertEquals(747, $entry->getValue());
         // Tamron 150-600mm G2
-        $this->assertEquals($entry->getText(), 'Canon EF 100-400mm f/4.5-5.6L IS II USM or Tamron Lens');
+        $this->assertEquals('Canon EF 100-400mm f/4.5-5.6L IS II USM or Tamron Lens', $entry->getText());
 
-        $this->assertTrue(count(Pel::getExceptions()) == 0);
+        $this->assertEquals(0, count(Pel::getExceptions()));
     }
 }

--- a/test/imagetests/NikonE950Test.php
+++ b/test/imagetests/NikonE950Test.php
@@ -21,7 +21,6 @@
  * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
  * Boston, MA 02110-1301 USA
  */
-
 namespace Pel\Test\imagetests;
 
 use lsolesen\pel\Pel;
@@ -30,6 +29,7 @@ use PHPUnit\Framework\TestCase;
 
 class NikonE950Test extends TestCase
 {
+
     public function testRead()
     {
         Pel::clearExceptions();


### PR DESCRIPTION
* PelIfd->load(PelDataWindow $d, $offset) will now throw a PelIfdException() instead of running into some undefined status
* PelFormat->getName($type) throws exception instead of returning a string which causes undefined steps in calling sources
* Improced constructor of PelEntryTime
* Updated some static method calls to non-static
* Some casts to "int" have been added
* Fixed "use" statements all over the code
* Fixed several false PhpDoc declarations
* Removed some unused variables
* Updated Readme for tests